### PR TITLE
show all derived images per page

### DIFF
--- a/ocrd_browser/model/page.py
+++ b/ocrd_browser/model/page.py
@@ -1,14 +1,21 @@
 from ocrd_models import OcrdFile, OcrdExif
 from ocrd_models.ocrd_page_generateds import PcGtsType, PageType, MetadataType
 from PIL.Image import Image
+from typing import List
 
 
 class Page:
-    def __init__(self, id_: str, file: OcrdFile, pc_gts: PcGtsType, image: Image, exif: OcrdExif):
+    def __init__(self, id_: str, file: OcrdFile, pc_gts: PcGtsType, image_files: List[OcrdFile], images: List[Image], exif: OcrdExif):
         self.id: str = id_
         self.file: OcrdFile = file
         self.pc_gts: PcGtsType = pc_gts
-        self.image: Image = image
+        # due to AlternativeImage on all hierarchy levels,
+        # a physical page can have multiple images or none;
+        # if it has none itself, a single image representing the page
+        # is extracted from the original image and the annotation
+        # of the top level
+        self.image_files: List[OcrdFile] = image_files
+        self.images: List[Image] = images
         self.exif: OcrdExif = exif
 
     @property

--- a/ocrd_browser/resources/main-window.ui
+++ b/ocrd_browser/resources/main-window.ui
@@ -75,7 +75,7 @@ THE SOFTWARE.
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="tooltip_text" translatable="yes">Open a project</property>
+                <property name="tooltip_text" translatable="yes">Open a workspace</property>
                 <property name="action_name">app.open</property>
                 <property name="use_underline">True</property>
               </object>

--- a/ocrd_browser/ui/dialogs.py
+++ b/ocrd_browser/ui/dialogs.py
@@ -26,6 +26,7 @@ class OpenDialog(Gtk.FileChooserDialog):
         filter_mets = Gtk.FileFilter()
         filter_mets.set_name("METS files")
         filter_mets.add_mime_type("application/mets+xml")
+        filter_mets.add_pattern("*.xml")
         self.add_filter(filter_mets)
 
         filter_any = Gtk.FileFilter()

--- a/ocrd_browser/util/image.py
+++ b/ocrd_browser/util/image.py
@@ -80,8 +80,10 @@ def pil_scale(orig: Image, w: int = None, h: int = None) -> Image:
     :return: ndarray
     """
     new_width, new_height = _calculate_scale(orig.width, orig.height, w, h)
-    thumb = orig.copy()
-    thumb.thumbnail((new_width, new_height))
+    # thumb = orig.copy()
+    # thumb.thumbnail((new_width, new_height))
+    # also allows enlarging:
+    thumb = orig.resize((new_width, new_height))
     return thumb
 
 

--- a/ocrd_browser/view/base.py
+++ b/ocrd_browser/view/base.py
@@ -102,7 +102,7 @@ class PageQtySelector(Gtk.Box, Configurator):
         super().__init__(visible=True, spacing=3)
         self.value = None
 
-        label = Gtk.Label(label='# Pages:', visible=True)
+        label = Gtk.Label(label='#Pages:', visible=True)
 
         self.pages = Gtk.SpinButton(visible=True, max_length=2, width_chars=2, max_width_chars=2, numeric=True)
         self.pages.set_tooltip_text('How many pages should be displayed at once?')
@@ -125,6 +125,34 @@ class PageQtySelector(Gtk.Box, Configurator):
     def changed(self, page_qty: int) -> None:
         self.value = page_qty
 
+class ImageZoomSelector(Gtk.Box, Configurator):
+
+    def __init__(self) -> None:
+        super().__init__(visible=True, spacing=3)
+        self.value = None
+
+        label = Gtk.Label(label='Zoom:', visible=True)
+
+        self.scale = Gtk.SpinButton(visible=True, max_length=3, width_chars=3, max_width_chars=3, numeric=True)
+        self.scale.set_tooltip_text('log scale factor for viewing images')
+        # noinspection PyCallByClass,PyArgumentList
+        self.scale.set_adjustment(Gtk.Adjustment.new(0, -20, 20, 1, 4, 3))
+        self.scale.set_snap_to_ticks(False)
+        self.scale.connect('value-changed', self.value_changed)
+
+        self.pack_start(label, False, True, 0)
+        self.pack_start(self.scale, False, True, 0)
+
+    def set_value(self, value: int) -> None:
+        self.value = value
+        self.scale.set_value(value)
+
+    def value_changed(self, spin: Gtk.SpinButton) -> None:
+        self.emit('changed', 1.2**(spin.get_value()))
+    
+    @GObject.Signal(arg_types=[float])
+    def changed(self, scale: float) -> None:
+        self.value = scale
 
 class FileGroupSelector(Gtk.Box, Configurator):
 

--- a/ocrd_browser/view/images.py
+++ b/ocrd_browser/view/images.py
@@ -81,5 +81,6 @@ class ViewImages(View):
                 if page:
                     thumbnail = pil_scale(page.image, None, self.preview_height - 10)
                     image.set_from_pixbuf(pil_to_pixbuf(thumbnail))
+                    image.set_tooltip_text(page.id)
                 else:
                     image.set_from_stock('missing-image', Gtk.IconSize.DIALOG)

--- a/ocrd_browser/view/images.py
+++ b/ocrd_browser/view/images.py
@@ -1,11 +1,17 @@
-from gi.repository import Gtk
+from gi.repository import Gtk, Gdk
 
 from typing import Any, List, Optional, Tuple
 
 from itertools import zip_longest
 from ocrd_browser.util.image import pil_to_pixbuf, pil_scale
 from ocrd_models.constants import NAMESPACES as NS
-from .base import View, FileGroupSelector, FileGroupFilter, PageQtySelector
+from .base import (
+    View,
+    FileGroupSelector,
+    FileGroupFilter,
+    PageQtySelector,
+    ImageZoomSelector
+)
 from ..model import Page
 
 
@@ -21,6 +27,7 @@ class ViewImages(View):
         self.file_group: Tuple[Optional[str], Optional[str]] = ('OCR-D-IMG', None)
         self.page_qty: int = 1
         self.preview_height: int = 10
+        self.scale: float = 1.0
         self.image_box: Optional[Gtk.Box] = None
         self.pages: List[Page] = []
 
@@ -29,15 +36,21 @@ class ViewImages(View):
 
         self.add_configurator('file_group', FileGroupSelector(FileGroupFilter.IMAGE))
         self.add_configurator('page_qty', PageQtySelector())
+        self.add_configurator('scale', ImageZoomSelector())
 
         self.image_box = Gtk.HBox(visible=True, homogeneous=True)
         self.viewport.add(self.image_box)
         self.rebuild_pages()
+        self.window.connect('scroll-event', self.on_scroll)
+        self.window.add_events(Gdk.EventMask.SCROLL_MASK |\
+                               Gdk.EventMask.SMOOTH_SCROLL_MASK)
 
     def config_changed(self, name: str, value: Any) -> None:
         super(ViewImages, self).config_changed(name, value)
         if name == 'page_qty':
             self.rebuild_pages()
+        if name == 'scale':
+            self.rescale()
         self.reload()
 
     def rebuild_pages(self) -> None:
@@ -78,7 +91,7 @@ class ViewImages(View):
     def on_size(self, _w: int, h: int, _x: int, _y: int) -> None:
         if abs(self.preview_height - h) > 4:
             self.preview_height = h
-            self.redraw()
+            self.rescale()
 
     def redraw(self) -> None:
         if self.pages:
@@ -96,12 +109,11 @@ class ViewImages(View):
                                           icon_size=Gtk.IconSize.DIALOG)
                         box.add(image)
                     if img:
-                        thumbnail = pil_scale(img, None, self.preview_height - 10)
-                        image.set_from_pixbuf(pil_to_pixbuf(thumbnail))
-                        img_file = page.image_files[i]
-                        if img_file == page.file:
+                        if page.image_files[0] == page.file:
+                            # PAGE-XML was created from the (first) image file directly
                             image.set_tooltip_text(page.id)
                         else:
+                            img_file = page.image_files[i]
                             # get segment ID for AlternativeImage as tooltip
                             img_id = page.pc_gts.gds_elementtree_node_.xpath(
                                 '//page:AlternativeImage[@filename="{}"]/../@id'.format(img_file.local_filename),
@@ -114,3 +126,35 @@ class ViewImages(View):
                         image.set_from_stock('missing-image', Gtk.IconSize.DIALOG)
                 for child in existing_images.values():
                     child.destroy()
+            self.rescale()
+    
+    def rescale(self) -> None:
+        if self.pages:
+            box: Gtk.Box
+            for box, page in zip_longest(self.image_box.get_children(), self.pages):
+                images = {child.get_name():
+                          child for child in box.get_children()}
+                for i, img in enumerate(page.images if page else [None]):
+                    name = 'image_{}'.format(i)
+                    image: Gtk.Image
+                    image = images[name]
+                    if img:
+                        thumbnail = pil_scale(img, None, int(self.scale * self.preview_height) - 10)
+                        image.set_from_pixbuf(pil_to_pixbuf(thumbnail))
+
+    def on_scroll(self, widget: Gtk.Widget, event: Gdk.EventButton):
+        # Handles zoom in / zoom out on Ctrl+mouse wheel
+        accel_mask = Gtk.accelerator_get_default_mod_mask()
+        if event.state & accel_mask == Gdk.ModifierType.CONTROL_MASK:
+            release, direction = event.get_scroll_direction()
+            if not release:
+                return False
+            if direction == Gdk.ScrollDirection.DOWN:
+                self.scale = max(0.01, self.scale * 0.8)
+            else:
+                self.scale = min(40.0, self.scale / 0.8)
+            self.rescale()
+            return False
+        else:
+            # delegate to normal scroll handler (vertical/horizontal navigation)
+            return True

--- a/ocrd_browser/view/text.py
+++ b/ocrd_browser/view/text.py
@@ -46,6 +46,7 @@ class ViewText(View):
 
     def redraw(self) -> None:
         if self.current:
+            self.text_view.set_tooltip_text(self.page_id)
             regions = self.current.pc_gts.get_Page().get_AllRegions(classes=['Text'], order='reading-order')
             text = ''
             for i, region in enumerate(regions):

--- a/ocrd_browser/view/xml.py
+++ b/ocrd_browser/view/xml.py
@@ -9,11 +9,6 @@ from ocrd_browser.view.base import FileGroupSelector, FileGroupFilter
 
 GObject.type_register(GtkSource.View)
 
-SPLIT = """
-... I'm sorry Dave, I'm afraid I can't do that ...
-... With bigger XML files there are frequent crashes ...                                                   
-"""
-
 
 class ViewXml(View):
     """
@@ -57,17 +52,8 @@ class ViewXml(View):
     def redraw(self) -> None:
         if self.current:
             text = to_xml(self.current.pc_gts)
-            # TODO: Crashes with big XML, as a workaround shorten the file
-            if len(text) > 50000:
-                self.buffer.set_highlight_syntax(False)
-                line_break_start = text.find("\n", 45000)
-                line_break_end = text.find("\n", len(text) - 5000)
-
-                text = text[:line_break_start] + SPLIT + text[line_break_end:]
-
-            else:
-                self.buffer.set_highlight_syntax(True)
-
+            # TODO: Crashes with big XML, as a workaround disable highlighting
+            self.buffer.set_highlight_syntax(len(text) <= 50000)
             self.buffer.set_text(text)
         else:
             self.buffer.set_text('')

--- a/ocrd_browser/view/xml.py
+++ b/ocrd_browser/view/xml.py
@@ -51,6 +51,7 @@ class ViewXml(View):
 
     def redraw(self) -> None:
         if self.current:
+            self.text_view.set_tooltip_text(self.page_id)
             text = to_xml(self.current.pc_gts)
             # TODO: Crashes with big XML, as a workaround disable highlighting
             self.buffer.set_highlight_syntax(len(text) <= 50000)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     version=__version__,
     author='Johannes Künsebeck',
     author_email='kuensebeck@googlemail.com',
-    description='An extensible viewer for OCR-D mets.xml files',
+    description='An extensible viewer for OCR-D workspaces',
     license='MIT License',
     long_description=codecs.open('README.md', encoding='utf-8').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This allows browsing AlternativeImages for all segments, and adds tooltips (showing the pageId and/or segment ID):

![ocrd_browser_alternativeimages](https://user-images.githubusercontent.com/38561704/96236070-da322900-0f9b-11eb-9b12-f2d26e40d261.png)

(I also removed the hilarious PAGE-XML split hack – it seems to be enough to just disable the highlighting. And the file open dialog needed a filename filter to allow picking anything.)

You may want to make a new release after the recent changes.