### PR TITLE
2 more fixes

### DIFF
--- a/ocrd_browser/model/document.py
+++ b/ocrd_browser/model/document.py
@@ -347,7 +347,9 @@ class Document:
         This is modelled after Processor.input_files https://github.com/OCR-D/core/pull/556/
         """
         log = getLogger('ocrd_browser.model.document.Document.page_for_id')
-        page_files = self.files_for_page_id(page_id, file_group, MIMETYPE_PAGE)
+        if not page_id:
+            return None
+        page_files = self.files_for_page_id(page_id, file_group, mimetype=MIMETYPE_PAGE)
         image_files = self.files_for_page_id(page_id, file_group, mimetype="//image/.*")
         images = [self.resolve_image(f) for f in image_files]
         if not page_files and not image_files:


### PR DESCRIPTION
The first is a workaround for Pillow#3011 Pillow#3159 Pillow#3838 Pillow#4402: Images with higher depth are poorly supported and must be converted ("by hand") to 8-bit before doing anything on the image.

The second fixes #18, actually.