### PR TITLE
initialize new views with current pageId

### DIFF
--- a/ocrd_browser/ui/window.py
+++ b/ocrd_browser/ui/window.py
@@ -102,6 +102,7 @@ class MainWindow(Gtk.ApplicationWindow):
         view: View = view_class(name, self)
         view.build()
         view.set_document(self.document)
+        view.page_activated(self, self.current_page_id)
         self.views.append(view)
         self.connect('page_activated', view.page_activated)
         self.page_list.connect('pages_selected', view.pages_selected)


### PR DESCRIPTION
This fixes the problem that new views start without a page, and you have to select a _different_ page in the page_list_store and then again select the _previous_ page to actually load it.