### PR TITLE
require gi >= 3.28

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ ocrd
 Pillow
 numpy<1.19.0,>=1.17.0
 opencv-python-headless
-PyGObject
+PyGObject >= 3.28
 python-magic
 wheel
 setuptools


### PR DESCRIPTION
This fixes a bug where the unqualified PyGObject dependency installed 3.26 which is too old and yields:

```
AttributeError: 'gi.repository.Gtk' object has no attribute 'Template'
```
