### PR TITLE
improve reading order and region order

### DIFF
--- a/ocrd_browser/model/page_xml_renderer.py
+++ b/ocrd_browser/model/page_xml_renderer.py
@@ -521,7 +521,7 @@ class PageXmlRenderer:
 
         if self.features & Feature.ORDER:
             last_point: Optional[Point] = None
-            for region_ds in page.get_AllRegions(classes=['Text'], order='reading-order'):
+            for region_ds in page.get_AllRegions(order='reading-order-only'):
                 region = self.region_factory.create(region_ds)
                 new_point = region.poly.representative_point()
                 if last_point:


### PR DESCRIPTION
Fixes #42 

Fixes regarding reading order:
- all region types that are in `ReadingOrder` should get arrows (i.e. no `classes` filter)
- no region types that are not in `ReadingOrder` should get arrows (i.e. `reading-order-only` instead of `reading-order`)

Fixes regarding rendering order:
- separators should always stay above other regions
- text regions should stay above other regions, but below separators