### PR TITLE
add Docker service with workspace indexing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.7
+
+COPY Makefile /Makefile
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3-dev make \
+    && make -f /Makefile deps-ubuntu \
+    && pip3 install -U setuptools --use-feature=2020-resolver \
+    && pip3 install browse-ocrd --use-feature=2020-resolver \
+    && rm /Makefile
+
+ENV GDK_BACKEND broadway
+ENV BROADWAY_DISPLAY :5
+
+EXPOSE 8085
+EXPOSE 8080
+
+VOLUME /data
+
+COPY init.sh /init.sh
+COPY serve.py /serve.py
+
+WORKDIR /
+CMD ["/init.sh", "/data"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN apt-get update \
     && pip3 install browse-ocrd --use-feature=2020-resolver \
     && rm /Makefile
 
+MAINTAINER https://github.com/hnesk/browse-ocrd/issues
+
 ENV GDK_BACKEND broadway
 ENV BROADWAY_DISPLAY :5
 

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,10 @@ PIP = pip3
 LOG_LEVEL = INFO
 PYTHONIOENCODING=utf8
 SHARE_DIR=~/.local/share
+DOCKER_TAG = ocrd_browser
 
 deps-ubuntu:
-	apt install -o Acquire::Retries=3 -y libcairo2-dev libgtk-3-dev libglib2.0-dev libgtksourceview-3.0-dev libgirepository1.0-dev gir1.2-webkit2-4.0 python3-dev pkg-config cmake
+	apt-get install -o Acquire::Retries=3 --no-install-recommends -y libcairo2-dev libgtk-3-bin libgtk-3-dev libglib2.0-dev libgtksourceview-3.0-dev libgirepository1.0-dev gir1.2-webkit2-4.0 python3-dev pkg-config cmake
 
 deps-dev:
 	$(PIP) install -r requirements-dev.txt
@@ -73,6 +74,15 @@ tests/assets: repo/assets
 	mkdir -p $@
 	cp -r -t $@ repo/assets/data/*
 
+docker-build:
+	docker build --tag $(DOCKER_TAG) .
+
+docker-run: DATADIR ?= $(CURDIR)
+docker-run:
+	docker run -it --rm -v $(DATADIR):/data -p 8085:8085 -p 8080:8080 $(DOCKER_TAG)
+
+docker-up:
+	docker-compose up -d
 
 .PHONY: assets-clean
 # Remove symlinks in test/assets

--- a/README.md
+++ b/README.md
@@ -1,9 +1,23 @@
+[![Unit tests](https://github.com/hnesk/browse-ocrd/workflows/Unit%20tests/badge.svg?branch=master)](https://github.com/hnesk/browse-ocrd/actions/workflows/unittest.yml)
+
 # OCR-D Browser
 
 An extensible viewer for [OCR-D](https://ocr-d.de/) [mets.xml](https://ocr-d.de/en/spec/mets) files
 
-[![Unit tests](https://github.com/hnesk/browse-ocrd/workflows/Unit%20tests/badge.svg?branch=master)](https://github.com/hnesk/browse-ocrd/actions/workflows/unittest.yml)
-
+ * [Screenshot](#screenshot)
+ * [Features](#features)
+ * [Installation](#installation)
+    * [Native](#native-tested-on-ubuntu-18042004)
+       * [From source](#from-source)
+       * [Via pip](#via-pip)
+    * [Docker](#docker)
+ * [Usage](#usage)
+    * [Native GUI](#native-gui)
+    * [Docker service](#docker-service)
+ * [Configuration](#configuration)
+    * [Configuration file locations](#configuration-file-locations)
+    * [Configuration file syntax](#configuration-file-syntax)
+ 
 ## Screenshot
 
 ![OCRD Browser with Page and Xml view](docs/screenshot.png)
@@ -20,10 +34,13 @@ An extensible viewer for [OCR-D](https://ocr-d.de/) [mets.xml](https://ocr-d.de/
 - DiffView: Show a simple diff comparison between text annotations from different fileGrps  
 - HtmlView: Show rendered HTML comparison from [dinglehopper](https://github.com/qurator-spk/dinglehopper) evaluations
 
+## Installation
 
-## Installation (tested on Ubuntu 18.04/20.04) 
+### Native (tested on Ubuntu 18.04/20.04) 
 
-In any case you need a venv with a current pip version (>=20), preferably your existing ocrd-venv:
+The native installation requires [GTK 3](https://www.gtk.org/).
+
+In any case you need a [virtual environment](https://packaging.python.org/tutorials/installing-packages/#creating-virtual-environments) with a current `pip` version (>=20), preferably your existing OCR-D venv:
 
 <details>
   <summary>Create a current pip venv:</summary>
@@ -37,7 +54,7 @@ pip install --upgrade pip setuptools wheel
 </details>
 
 
-### From source
+#### From source
 ```bash
 git clone https://github.com/hnesk/browse-ocrd.git 
 cd browse-ocrd
@@ -45,17 +62,44 @@ sudo make deps-ubuntu
 make install
 ```
 
-### Via pip 
+#### Via pip
 
 ```bash
 sudo apt install libcairo2-dev libgirepository1.0-dev
 pip install browse-ocrd
 ```
- 
+
+### Docker
+
+If you have installed [Docker](https://docs.docker.com/get-docker/), you can build OCR-D Browser as a **web service**:
+
+    docker build -t ocrd_browser .
+
+Or use a prebuilt image from Dockerhub:
+
+    docker pull bertsky/ocrd_browser
+
+
 ## Usage
+
+### Native GUI
+Start the app with the filesystem path to the METS file of your [OCR-D workspace](https://ocr-d.de/en/spec/glossary#workspace):
 ```
-browse-ocrd ./path/to/mets.xml # or open interactively
+browse-ocrd ./path/to/mets.xml
 ```
+
+You can still open another METS file from the UI though.
+
+### Docker service
+
+When running the webservice, you need to pass a directory `DATADIR` which (recursively) contains all the workspaces you want to serve.
+The top entrypoint `http://localhost/` will show an index page with a link `http://localhost/browse/...` for each workspace path.
+Each link will run `browse-ocrd` at that workspace in the background, and then redirect your browser to the internal [Broadway server](https://docs.gtk.org/gtk3/broadway.html), which renders the app in the web browser.
+
+To start up, just do:
+
+    docker run -it --rm -v DATADIR:/data -p 8085:8085 -p 8080:8080 ocrd_browser
+
 
 ## Configuration
 

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -x
+broadwayd :5 &
+python serve.py -p 8080 -P 8085 -d "${1:-/data}"

--- a/serve.py
+++ b/serve.py
@@ -18,6 +18,8 @@ class RequestHandler(SimpleHTTPRequestHandler):
     basedir = "."
 
     def do_GET(self):
+        # FIXME: HTTP auth # self.server.auth / self.checkAuthentication()
+        self.bwhost = self.headers.get('Host').split(':')[0]
         # serve a listing of available workspaces with links to ocrd-browse them
         if self.path == '/':
             self._serve_workspaces()

--- a/serve.py
+++ b/serve.py
@@ -1,0 +1,126 @@
+import os
+import sys
+import io
+from functools import lru_cache
+from pathlib import Path
+from subprocess import Popen
+from shutil import which
+import html
+from http import HTTPStatus
+from http.server import SimpleHTTPRequestHandler
+from socketserver import ForkingTCPServer
+import urllib
+import click
+
+class RequestHandler(SimpleHTTPRequestHandler):
+    bwhost = "localhost"
+    bwport = 8085
+    basedir = "."
+
+    def do_GET(self):
+        # serve a listing of available workspaces with links to ocrd-browse them
+        if self.path == '/':
+            self._serve_workspaces()
+        # serve a single workspace
+        elif self.path.startswith('/browse/'):
+            path = self.path[7:].lstrip('/')
+            path = urllib.parse.unquote(path)
+            path = os.path.join(self.basedir, path)
+            self._browse_workspace(path)
+        elif self.path == '/reindex':
+            self._workspaces.cache_clear()
+            self.send_response(HTTPStatus.OK)
+        else:
+            #SimpleHTTPRequestHandler.do_GET(self)
+            self.send_response(HTTPStatus.FORBIDDEN)
+
+    def do_POST(self):
+        self.do_GET()
+
+    @property
+    @lru_cache(maxsize=1)
+    def _workspaces(self):
+        # recursively find METS file paths
+        paths = []
+        for mets in Path(self.basedir).rglob('mets.xml'):
+            if mets.match('.backup/*/mets.xml'):
+                continue
+            print(mets)
+            paths.append(str(mets))
+        return paths
+
+    def _serve_workspaces(self):
+        # generate HTML with links
+        enc = sys.getfilesystemencoding()
+        basedir = os.path.realpath(self.basedir)
+        title = html.escape(basedir, quote=False)
+        title = 'OCR-D Browser for workspaces at %s' % title
+        r = []
+        r.append('<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" '
+                 '"http://www.w3.org/TR/html4/strict.dtd">')
+        r.append('<html>\n<head>')
+        r.append('<meta http-equiv="Content-Type" '
+                 'content="text/html; charset=%s">' % enc)
+        r.append('<title>%s</title>\n</head>' % title)
+        r.append('<body>\n<h1>%s</h1>' % title)
+        r.append('<hr>\n<ul>')
+        for name in self._workspaces:
+            relname = os.path.relpath(name, basedir)
+            linkname = os.path.join('/browse', relname)
+            r.append('<li><a href="%s">%s</a></li>'
+                     % (urllib.parse.quote(linkname, errors='surrogatepass'),
+                        html.escape(relname, quote=False)))
+        r.append('</ul>\n<hr>\n</body>\n</html>\n')
+        # write to file
+        encoded = '\n'.join(r).encode(enc, 'surrogateescape')
+        f = io.BytesIO()
+        f.write(encoded)
+        f.seek(0)
+        # send file
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-type", "text/html; charset=%s" % enc)
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.copyfile(f, self.wfile)
+
+    def _browse_workspace(self, path):
+        if not os.path.exists(path):
+            self.send_response(HTTPStatus.NOT_FOUND)
+        else:
+            if not path.endswith('mets.xml'):
+                path = os.path.join(path, 'mets.xml')
+            ## run app
+            ret = Popen([which('browse-ocrd'),
+                         '--display', ':' + str(self.bwport - 8080),
+                         path])
+            ## proxy does not work, because the follow-up requests would need to be forwarded, too:
+            # response = urllib.request.urlopen('http://' + self.bwhost + ':' + str(self.bwport))
+            # self.send_response(response.status)
+            # for name, value in response.getheaders():
+            #     self.send_header(name.rstrip(':'), value)
+            # self.end_headers()
+            # self.copyfile(response, self.wfile)
+            ## so let's use temporary redirect instead
+            self.send_response(HTTPStatus.SEE_OTHER) # or TEMPORARY_REDIRECT?
+            self.send_header('Location', 'http://' + self.bwhost + ':' + str(self.bwport))
+            self.end_headers()
+
+    # def log_message(self, format, *args):
+    #     """ Override to prevent stdout on requests """
+    #     pass
+
+@click.command(context_settings={'help_option_names': ['-h', '--help']})
+@click.option('-P', '--bwport', default=8085, type=int, help="TCP port of Broadwayd to delegate to")
+@click.option('-p', '--port', default=80, type=int, help="TCP port to bind the web server to")
+@click.option('-l', '--listen', default="", type=str, help="network address to bind the web server to")
+@click.option('-d', '--basedir', default=".", type=click.Path(exists=True, file_okay=False))                    
+def cli(bwport, port, listen, basedir):
+    Handler = RequestHandler
+    Handler.bwport = bwport
+    Handler.basedir = basedir
+    ForkingTCPServer.allow_reuse_address = True
+    with ForkingTCPServer((listen, port), Handler) as httpd:
+        httpd.serve_forever()
+
+if __name__ == '__main__':
+    cli()


### PR DESCRIPTION
This adds the [recipe](https://github.com/OCR-D/ocrd-website/wiki/browse-ocrd-in-Docker) by @b2m for running OCR-D Browser inside a Broadwayd via Docker into the repository. I took the liberty of extending that idea with a simplistic indexing service which just searches for all METS files in the startup directory recursively, and presents a web page with links to each of them. The links then in turn will start up `browse-ocrd` and redirect to the local Broadwayd site.

Here's a screenshot of the index page:
![ocrd-browser-browser](https://user-images.githubusercontent.com/38561704/172007547-bfc08913-d73a-4947-9d87-10294f5b91d1.png)

And that's what you get by clicking on one of the links:
![ocrd-browser-broadway](https://user-images.githubusercontent.com/38561704/172007793-31b0b0a8-8be6-4503-9519-b22b2e598896.png)


