### PR TITLE
Performance improvements

### DIFF
--- a/ocrd_browser/application.py
+++ b/ocrd_browser/application.py
@@ -2,10 +2,14 @@ from gi.repository import Gio, Gtk, GLib, Gdk
 
 from typing import List
 
-from importlib.metadata import entry_points
 from ocrd_browser.util.gtk import ActionRegistry
 from ocrd_browser.ui import MainWindow, AboutDialog, OpenDialog
 from ocrd_browser.view import ViewRegistry
+
+try:
+    from importlib.metadata import entry_points
+except ModuleNotFoundError:
+    from importlib_metadata import entry_points  # type: ignore
 
 
 class OcrdBrowserApplication(Gtk.Application):

--- a/ocrd_browser/application.py
+++ b/ocrd_browser/application.py
@@ -1,8 +1,8 @@
 from gi.repository import Gio, Gtk, GLib, Gdk
 
-import pkg_resources
 from typing import List
 
+from importlib.metadata import entry_points
 from ocrd_browser.util.gtk import ActionRegistry
 from ocrd_browser.ui import MainWindow, AboutDialog, OpenDialog
 from ocrd_browser.view import ViewRegistry
@@ -36,7 +36,7 @@ class OcrdBrowserApplication(Gtk.Application):
         self.set_accels_for_action('view.zoom_to::width', ['<Ctrl>numbersign'])
         self.set_accels_for_action('view.zoom_to::page', ['<Ctrl><Alt>numbersign'])
 
-        for entry_point in pkg_resources.iter_entry_points('ocrd_browser_ext'):
+        for entry_point in entry_points().get('ocrd_browser_ext', []):
             (entry_point.load())(self)
 
         self.load_css()

--- a/ocrd_browser/application.py
+++ b/ocrd_browser/application.py
@@ -65,7 +65,7 @@ class OcrdBrowserApplication(Gtk.Application):
         open_windows: int = 0
         window: MainWindow
         for window in self.get_windows():
-            if isinstance(window, MainWindow) and window.close_confirm():  # type: ignore[unreachable]
+            if isinstance(window, MainWindow) and window.close_confirm():
                 window.destroy()
             else:
                 open_windows += 1

--- a/ocrd_browser/main.py
+++ b/ocrd_browser/main.py
@@ -2,7 +2,6 @@
 # -*- Mode: Python; coding: utf-8; indent-tabs-mode: t; c-basic-offset: 4; tab-width: 4 -*-
 import os
 import sys
-from pstats import SortKey
 import pstats
 import io
 import cProfile
@@ -49,7 +48,7 @@ def install_excepthook() -> None:
 def startup_time() -> None:
     PROFILER.disable()
     s = io.StringIO()
-    ps = pstats.Stats(PROFILER, stream=s).sort_stats(SortKey.TIME)
+    ps = pstats.Stats(PROFILER, stream=s).sort_stats(pstats.SortKey.TIME)
     ps.print_stats(20)
     print(s.getvalue())
 

--- a/ocrd_browser/main.py
+++ b/ocrd_browser/main.py
@@ -3,7 +3,8 @@
 import os
 import sys
 from pstats import SortKey
-import pstats, io
+import pstats
+import io
 import cProfile
 
 import gi
@@ -31,6 +32,7 @@ if 'STARTUP_PROFILE' in os.environ:
     PROFILER = cProfile.Profile()
     PROFILER.enable()
 
+
 def install_excepthook() -> None:
     """ Make sure we exit when an unhandled exception occurs. """
     old_hook = sys.excepthook
@@ -44,7 +46,7 @@ def install_excepthook() -> None:
     sys.excepthook = new_hook
 
 
-def startup_time():
+def startup_time() -> None:
     PROFILER.disable()
     s = io.StringIO()
     ps = pstats.Stats(PROFILER, stream=s).sort_stats(SortKey.TIME)

--- a/ocrd_browser/model/document.py
+++ b/ocrd_browser/model/document.py
@@ -162,7 +162,7 @@ class Document:
         """
         return str(self.workspace.baseurl) + '/' + self.mets_filename if self.workspace else None
 
-    def path(self, other: Union[OcrdFile, Path, str]) -> Path:
+    def path(self, other: Union[OcrdFile, Path, str]) -> Optional[Path]:
         """
         Resolves other relative to current workspace
         """
@@ -445,6 +445,7 @@ class Document:
             if self._original_url:
                 self.workspace = self._clone_workspace(self._original_url)
             else:
+                # noinspection PyTypeChecker
                 self.workspace = Resolver().workspace_from_nothing(directory=None, mets_basename='mets.xml')
         else:
             self.workspace = Resolver().workspace_from_url(self.baseurl_mets)

--- a/ocrd_browser/model/document.py
+++ b/ocrd_browser/model/document.py
@@ -14,11 +14,11 @@ from ocrd_browser.util.image import add_dpi_to_png_buffer
 from ocrd_browser.util.streams import SilencedStreams
 from ocrd_modelfactory import page_from_file
 from ocrd_models.constants import NAMESPACES as NS
+from ocrd_models import OcrdFile
 from ocrd_utils import pushd_popd
 from ocrd_utils.constants import MIME_TO_EXT
 from ocrd_utils import getLogger
 
-from collections import OrderedDict
 from pathlib import Path
 from tempfile import mkdtemp
 from datetime import datetime
@@ -29,7 +29,6 @@ import cv2
 
 if TYPE_CHECKING:
     from ocrd import Workspace
-    from ocrd_models import OcrdFile
     from ocrd_models.ocrd_page_generateds import PcGtsType
     # noinspection PyProtectedMember
     from lxml.etree import ElementBase as Element, _ElementTree as ElementTree
@@ -226,7 +225,7 @@ class Document:
 
         @return: List[Tuple[str,str]]
         """
-        distinct_groups: OrderedDict[Tuple[str, str], None] = OrderedDict()
+        distinct_groups: Dict[Tuple[str, str], None] = {}
         for el in self.xpath('mets:fileSec/mets:fileGrp[@USE]/mets:file[@MIMETYPE]'):
             distinct_groups[(el.getparent().get('USE'), el.get('MIMETYPE'))] = None
 

--- a/ocrd_browser/model/document.py
+++ b/ocrd_browser/model/document.py
@@ -1,35 +1,39 @@
+from __future__ import annotations
+from typing import Optional, Tuple, List, Set, Union, cast, Callable, Any, Dict, TYPE_CHECKING
+
 import atexit
 import errno
 import os
 import shutil
 from functools import wraps
 
-from ocrd import Workspace, Resolver
+from ocrd import Resolver
 from ocrd_browser.model.page import Page
 from ocrd_browser.util.file_groups import best_file_group
 from ocrd_browser.util.image import add_dpi_to_png_buffer
 from ocrd_browser.util.streams import SilencedStreams
 from ocrd_modelfactory import page_from_file
-from ocrd_models import OcrdFile
-from ocrd_models.ocrd_page_generateds import PcGtsType
 from ocrd_models.constants import NAMESPACES as NS
 from ocrd_utils import pushd_popd
 from ocrd_utils.constants import MIME_TO_EXT
 from ocrd_utils import getLogger
 
-from typing import Optional, Tuple, List, Set, Union, cast, Callable, Any, Dict
 from collections import OrderedDict
 from pathlib import Path
 from tempfile import mkdtemp
 from datetime import datetime
 from urllib.parse import urlparse, unquote
-# noinspection PyProtectedMember
-from lxml.etree import ElementBase as Element, _ElementTree as ElementTree
-
-from numpy import array as ndarray
 from PIL import Image
 
 import cv2
+
+if TYPE_CHECKING:
+    from ocrd import Workspace
+    from ocrd_models import OcrdFile
+    from ocrd_models.ocrd_page_generateds import PcGtsType
+    # noinspection PyProtectedMember
+    from lxml.etree import ElementBase as Element, _ElementTree as ElementTree
+    from numpy import array as ndarray
 
 EventCallBack = Optional[Callable[[str, Any], None]]
 
@@ -60,11 +64,11 @@ class Document:
             os.chdir(self.workspace.directory)
 
     @classmethod
-    def create(cls, emitter: EventCallBack = None) -> 'Document':
+    def create(cls, emitter: EventCallBack = None) -> Document:
         return cls(None, emitter=emitter)
 
     @classmethod
-    def load(cls, mets_url: Union[Path, str] = None, emitter: EventCallBack = None) -> 'Document':
+    def load(cls, mets_url: Union[Path, str] = None, emitter: EventCallBack = None) -> Document:
         """
         Load a project from an url as a readonly view
 
@@ -80,7 +84,7 @@ class Document:
         return doc
 
     @classmethod
-    def clone(cls, mets_url: Union[Path, str], emitter: EventCallBack = None, editable: bool = True) -> 'Document':
+    def clone(cls, mets_url: Union[Path, str], emitter: EventCallBack = None, editable: bool = True) -> Document:
         """
         Clones a project (mets.xml and all used files) to a temporary directory for editing
         """
@@ -407,7 +411,7 @@ class Document:
 
     @check_editable
     def add_image(self, image: ndarray, page_id: str, file_id: str, file_group: str = 'OCR-D-IMG', dpi: int = 300,
-                  mimetype: str = 'image/png') -> 'OcrdFile':
+                  mimetype: str = 'image/png') -> OcrdFile:
         extension = MIME_TO_EXT[mimetype]
         retval, image_array = cv2.imencode(extension, image)
         image_bytes = add_dpi_to_png_buffer(image_array.tostring(), dpi)

--- a/ocrd_browser/model/page.py
+++ b/ocrd_browser/model/page.py
@@ -64,6 +64,7 @@ class Page:
         elif self.image_files:
             return next(iter(self.image_files))
         else:
+            # noinspection PyTypeChecker
             any_files = self.get_files(mimetype=None)
             if any_files:
                 return next(iter(any_files))

--- a/ocrd_browser/ui/dialogs.py
+++ b/ocrd_browser/ui/dialogs.py
@@ -1,11 +1,12 @@
 from gi.repository import Gtk, GdkPixbuf
 from typing import Any
-from pkg_resources import resource_filename
+
+from ocrd_browser.util.gtk import resource_string
 from ocrd_browser import __version__
 from ocrd_browser.model import Document
 
 
-@Gtk.Template(filename=resource_filename(__name__, '../resources/about-dialog.ui'))
+@Gtk.Template(string=resource_string('about-dialog.ui'))
 class AboutDialog(Gtk.AboutDialog):
     __gtype_name__ = "AboutDialog"
 
@@ -16,7 +17,7 @@ class AboutDialog(Gtk.AboutDialog):
         self.set_version(__version__)
 
 
-@Gtk.Template(filename=resource_filename(__name__, '../resources/open-dialog.ui'))
+@Gtk.Template(string=resource_string('open-dialog.ui'))
 class OpenDialog(Gtk.FileChooserDialog):
     __gtype_name__ = "OpenDialog"
 
@@ -36,7 +37,7 @@ class OpenDialog(Gtk.FileChooserDialog):
         self.add_filter(filter_any)
 
 
-@Gtk.Template(filename=resource_filename(__name__, '../resources/save-dialog.ui'))
+@Gtk.Template(string=resource_string('save-dialog.ui'))
 class SaveDialog(Gtk.FileChooserDialog):
     __gtype_name__ = "SaveDialog"
 

--- a/ocrd_browser/ui/page_browser.py
+++ b/ocrd_browser/ui/page_browser.py
@@ -2,12 +2,12 @@ from gi.repository import Gtk, Gdk, Pango, Gio, GObject
 
 from typing import List, Callable, Optional, Any, cast
 
-from pkg_resources import resource_filename
+from ocrd_browser.util.gtk import resource_string
 from ocrd_browser.model import Document
 from .page_store import PageListStore, ChangeList
 
 
-@Gtk.Template(filename=resource_filename(__name__, '../resources/page-list.ui'))
+@Gtk.Template(string=resource_string('page-list.ui'))
 class PagePreviewList(Gtk.IconView):
     __gtype_name__ = "PagePreviewList"
 

--- a/ocrd_browser/ui/window.py
+++ b/ocrd_browser/ui/window.py
@@ -3,22 +3,20 @@ from ocrd_models import OcrdFile
 
 from ocrd_browser.model import Document
 from ocrd_browser.view import ViewRegistry, ViewPage
-from ocrd_browser.util.gtk import ActionRegistry
+from ocrd_browser.util.gtk import ActionRegistry, resource_string
 from .dialogs import SaveDialog, SaveChangesDialog
 from .page_browser import PagePreviewList
-from pkg_resources import resource_filename
 from typing import List, cast, Any, Optional
 
 from ..view.manager import ViewManager
 
 
-@Gtk.Template(filename=resource_filename(__name__, '../resources/main-window.ui'))
+@Gtk.Template(string=resource_string('main-window.ui'))
 class MainWindow(Gtk.ApplicationWindow):
     __gtype_name__ = "MainWindow"
 
     header_bar: Gtk.HeaderBar = Gtk.Template.Child()
     page_list_scroller: Gtk.ScrolledWindow = Gtk.Template.Child()
-    panes: Gtk.Paned = Gtk.Template.Child()
     current_page_label: Gtk.Label = Gtk.Template.Child()
     view_container: Gtk.Box = Gtk.Template.Child()
     view_menu_box: Gtk.Box = Gtk.Template.Child()

--- a/ocrd_browser/util/config.py
+++ b/ocrd_browser/util/config.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 from collections import OrderedDict
 from configparser import ConfigParser
@@ -13,7 +14,7 @@ ConfigDict = MutableMapping[str, str]
 
 class _SubSettings:
     @classmethod
-    def from_section(cls, _name: str, section: ConfigDict) -> '_SubSettings':
+    def from_section(cls, _name: str, section: ConfigDict) -> _SubSettings:
         raise NotImplementedError('please override from_section')
 
     def validate(self) -> None:
@@ -28,7 +29,7 @@ class _FileGroups(_SubSettings):
         self.preferred_images = preferred_images
 
     @classmethod
-    def from_section(cls, _name: str, section: ConfigDict) -> '_FileGroups':
+    def from_section(cls, _name: str, section: ConfigDict) -> _FileGroups:
         preferred_images = section.get('preferredImages', 'OCR-D-IMG, OCR-D-IMG.*')
         return cls(
             [grp.strip() for grp in preferred_images.split(',')]
@@ -50,7 +51,7 @@ class _Tool(_SubSettings):
             raise ValueError('Could not locate executable "{}"'.format(executable))
 
     @classmethod
-    def from_section(cls, name: str, section: ConfigDict) -> '_Tool':
+    def from_section(cls, name: str, section: ConfigDict) -> _Tool:
         return cls(
             name[len(cls.PREFIX):],
             section['commandline'],
@@ -78,13 +79,13 @@ class Settings:
         return '{}({})'.format(self.__class__.__name__, repr(vars(self)))
 
     @classmethod
-    def get(cls) -> 'Settings':
+    def get(cls) -> Settings:
         if cls._settings is None:
             cls._settings = Settings.build_default()
         return cls._settings
 
     @classmethod
-    def build_default(cls, config_dirs: Optional[List[str]] = None, validate: bool = True) -> 'Settings':
+    def build_default(cls, config_dirs: Optional[List[str]] = None, validate: bool = True) -> Settings:
         if config_dirs is None:
             config_dirs = GLib.get_system_config_dirs() + [GLib.get_user_config_dir()]
             try:
@@ -97,7 +98,7 @@ class Settings:
         return cls.build_from_files(config_files, validate)
 
     @classmethod
-    def build_from_files(cls, files: List[str], validate: bool = True) -> 'Settings':
+    def build_from_files(cls, files: List[str], validate: bool = True) -> Settings:
         log = getLogger('ocrd_browser.util.config._Settings.build_from_files')
         config = ConfigParser()
         setattr(config, 'optionxform', lambda option: option)

--- a/ocrd_browser/util/config.py
+++ b/ocrd_browser/util/config.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 import os
-from collections import OrderedDict
 from configparser import ConfigParser
 import shlex
 from typing import List, Optional, MutableMapping
@@ -67,7 +66,7 @@ class Settings:
         self.file_groups = _FileGroups.from_section('FileGroups', config['FileGroups'] if 'FileGroups' in config else {'': ''})
         if validate:
             self.file_groups.validate()
-        self.tools = OrderedDict()
+        self.tools = {}
         for name, section in config.items():
             if name.startswith(_Tool.PREFIX):
                 tool = _Tool.from_section(name, section)

--- a/ocrd_browser/util/gtk.py
+++ b/ocrd_browser/util/gtk.py
@@ -1,5 +1,7 @@
 from gi.repository import Gio, GLib, Gtk
 
+from importlib import resources
+
 from typing import Callable, Dict, Optional, Set, Any
 
 ActionCallback = Optional[Callable[[Gio.SimpleAction, Any], None]]
@@ -102,3 +104,7 @@ class WhenIdle:
             callback()
             self._callbacks.remove(callback)
             self._runner_callback(self._run)
+
+
+def resource_string(resource, package = 'ocrd_browser.resources'):
+    return resources.read_text(package, resource)

--- a/ocrd_browser/util/gtk.py
+++ b/ocrd_browser/util/gtk.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from gi.repository import Gio, GLib, Gtk
 
 from importlib import resources
@@ -72,14 +73,14 @@ class WhenIdle:
 
     Usage: see WhenIdle.call
     """
-    _instance: 'WhenIdle' = None
+    _instance: WhenIdle = None
 
     def __init__(self, runner_callback: Callable):  # type: ignore[type-arg]
         self._runner_callback = runner_callback
         self._callbacks: Set[Callback] = set()
 
     @classmethod
-    def instance(cls) -> 'WhenIdle':
+    def instance(cls) -> WhenIdle:
         if cls._instance is None:
             cls._instance = cls(GLib.idle_add)
         return cls._instance

--- a/ocrd_browser/util/gtk.py
+++ b/ocrd_browser/util/gtk.py
@@ -107,5 +107,5 @@ class WhenIdle:
             self._runner_callback(self._run)
 
 
-def resource_string(resource, package = 'ocrd_browser.resources'):
+def resource_string(resource: str, package: str = 'ocrd_browser.resources') -> str:
     return resources.read_text(package, resource)

--- a/ocrd_browser/util/gtk.py
+++ b/ocrd_browser/util/gtk.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 from gi.repository import Gio, GLib, Gtk
 
-from importlib import resources
-
 from typing import Callable, Dict, Optional, Set, Any
+
+try:
+    from importlib.resources import read_text
+except ModuleNotFoundError:
+    from importlib_resources import read_text  # type: ignore
+
 
 ActionCallback = Optional[Callable[[Gio.SimpleAction, Any], None]]
 
@@ -108,4 +112,4 @@ class WhenIdle:
 
 
 def resource_string(resource: str, package: str = 'ocrd_browser.resources') -> str:
-    return resources.read_text(package, resource)
+    return read_text(package, resource)

--- a/ocrd_browser/view/__init__.py
+++ b/ocrd_browser/view/__init__.py
@@ -1,5 +1,4 @@
 from .base import View
-from .registry import ViewRegistry
 from .html import ViewHtml
 from .images import ViewImages
 from .text import ViewText
@@ -7,6 +6,7 @@ from .xml import ViewXml
 from .empty import ViewEmpty
 from .diff import ViewDiff
 from .page import ViewPage
+from .registry import ViewRegistry
 
 
 __all__ = ['View', 'ViewRegistry', 'ViewImages', 'ViewText', 'ViewXml', 'ViewHtml', 'ViewEmpty', 'ViewDiff', 'ViewPage']

--- a/ocrd_browser/view/base.py
+++ b/ocrd_browser/view/base.py
@@ -1,26 +1,27 @@
-from math import log
-
 from gi.repository import Gtk, Pango, GObject
 
-from typing import List, Tuple, Any, Optional, Dict, cast
+from typing import List, Tuple, Any, Optional, Dict, cast, TYPE_CHECKING
 
+from math import log
 from enum import Enum
 
 from ocrd_utils.constants import MIMETYPE_PAGE, MIME_TO_EXT
-from ocrd_browser.model import Document, Page
 from ocrd_browser.util.gtk import WhenIdle
+
+if TYPE_CHECKING:
+    from ocrd_browser.model import Document, Page
 
 
 class Configurator(Gtk.Widget):
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self.document: Optional[Document] = None
+        self.document: Optional['Document'] = None
         self.value: Any = None
 
-    def set_document(self, document: Document) -> None:
+    def set_document(self, document: 'Document') -> None:
         self.document = document
 
-    def set_page(self, page: Page) -> None:
+    def set_page(self, page: 'Page') -> None:
         pass
 
     def set_value(self, value: Any) -> None:
@@ -33,7 +34,7 @@ class View:
     def __init__(self, name: str, window: Gtk.Window):
         self.name: str = name
         self.window: Gtk.Window = window
-        self.document: Document = None
+        self.document: 'Document' = None
         self.current: Page = None
         self.page_id: str = None
 
@@ -54,7 +55,7 @@ class View:
         self.container.pack_start(self.action_bar, False, True, 0)
         self.container.pack_start(self.scroller, True, True, 0)
 
-    def set_document(self, document: Document) -> None:
+    def set_document(self, document: 'Document') -> None:
         self.document = document
         for configurator in self.configurators.values():
             configurator.set_document(document)
@@ -226,7 +227,7 @@ class FileGroupSelector(Gtk.Box, Configurator):
         if active_id:
             self.groups.set_active_id(active_id)
 
-    def set_document(self, document: Document) -> None:
+    def set_document(self, document: 'Document') -> None:
         self.groups.set_document(document)
         self.set_value(self.value)
 
@@ -270,7 +271,7 @@ class FileGroupComboBox(Gtk.ComboBox):
             return True
         return False
 
-    def set_document(self, document: Document) -> None:
+    def set_document(self, document: 'Document') -> None:
         self.set_model(FileGroupModel.build(document, self.filter))
         # self.set_active(0)
 
@@ -284,7 +285,7 @@ class FileGroupComboBox(Gtk.ComboBox):
 
 
 class FileGroupModel(Gtk.ListStore):
-    def __init__(self, document: Document):
+    def __init__(self, document: 'Document'):
         super().__init__(str, str, str, str)
         for group, mime in document.file_groups_and_mimetypes:
             if mime == 'text/html':
@@ -294,7 +295,7 @@ class FileGroupModel(Gtk.ListStore):
             self.append(('{}|{}'.format(group, mime), group, mime, ext))
 
     @classmethod
-    def build(cls, document: Document, filter_: 'FileGroupFilter' = None) -> 'FileGroupModel':
+    def build(cls, document: 'Document', filter_: 'FileGroupFilter' = None) -> 'FileGroupModel':
         model = cls(document)
         model = model.filter_new()
         model.set_visible_func(filter_ if filter_ else FileGroupFilter.ALL)

--- a/ocrd_browser/view/diff.py
+++ b/ocrd_browser/view/diff.py
@@ -80,7 +80,7 @@ class ViewDiff(View):
         self.file_group2: Tuple[Optional[str], Optional[str]] = (None, MIMETYPE_PAGE)
         self.font_size: Optional[int] = None
 
-        self.current2: Page = None
+        self.current2: Optional[Page] = None
 
         # noinspection PyTypeChecker
         self.text_view: GtkSource.View = None

--- a/ocrd_browser/view/registry.py
+++ b/ocrd_browser/view/registry.py
@@ -1,5 +1,6 @@
-from pkg_resources import EntryPoint, iter_entry_points
-from typing import Dict, Tuple, Optional
+from __future__ import annotations
+from importlib.metadata import entry_points
+from typing import Dict, Tuple, Optional, Type
 from .base import View
 
 ViewInfo = Tuple[type, str, str]
@@ -10,10 +11,9 @@ class ViewRegistry:
         self.views = views
 
     @classmethod
-    def create_from_entry_points(cls) -> 'ViewRegistry':
+    def create_from_entry_points(cls) -> ViewRegistry:
         views = {}
-        entry_point: EntryPoint
-        for entry_point in iter_entry_points('ocrd_browser_view'):
+        for entry_point in entry_points().get('ocrd_browser_view', []):
             view_class = entry_point.load()
             assert issubclass(view_class, View)
             label = view_class.label if hasattr(view_class, 'label') else view_class.__name__
@@ -24,5 +24,5 @@ class ViewRegistry:
     def get_view_options(self) -> Dict[str, str]:
         return {id_: label for id_, (view_class, label, description) in self.views.items()}
 
-    def get_view(self, id_: str) -> Optional[type]:
+    def get_view(self, id_: str) -> Optional[Type[View]]:
         return self.views[id_][0] if id_ in self.views else None

--- a/ocrd_browser/view/registry.py
+++ b/ocrd_browser/view/registry.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
-from importlib.metadata import entry_points
 from typing import Dict, Tuple, Optional, Type
 from .base import View
+
+try:
+    from importlib.metadata import entry_points
+except ModuleNotFoundError:
+    from importlib_metadata import entry_points  # type: ignore
+
 
 ViewInfo = Tuple[type, str, str]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ setuptools
 lxml
 Shapely
 Deprecated
+importlib_metadata;python_version<'3.8'
+importlib_resources;python_version<'3.8'

--- a/serve.py
+++ b/serve.py
@@ -92,7 +92,7 @@ class RequestHandler(SimpleHTTPRequestHandler):
             if not path.endswith('mets.xml'):
                 path = os.path.join(path, 'mets.xml')
             ## run app
-            ret = Popen([which('browse-ocrd'),
+            Popen([which('browse-ocrd'),
                          '--display', ':' + str(self.bwport - 8080),
                          path])
             ## proxy does not work, because the follow-up requests would need to be forwarded, too:

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import fastentrypoints
+import fastentrypoints  # lgtm [py/unused-import]
 import codecs
 import subprocess
 


### PR DESCRIPTION
Gettting rid of pkg_resources brings a good performance improvement, from 1.178s to 0.864s in startup time on my machine
Contains also some less `import`s when not TYPE_CHECKING 

```
$ STARTUP_PROFILE=1 browse-ocrd 
         1389599 function calls (1321032 primitive calls) in 1.178 seconds

   Ordered by: internal time
   List reduced from 4716 to 20 due to restriction <20>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
39203/262    0.063    0.000    0.243    0.001 /home/jk/Projekte/ocrd_all_2020/venv/lib/python3.8/site-packages/pkg_resources/_vendor/pyparsing.py:1370(_parseNoCache)
        1    0.063    0.063    0.130    0.130 /home/jk/Projekte/ocrd_all_2020/venv/lib/python3.8/site-packages/ocrd_browser/application.py:53(do_activate)
      575    0.051    0.000    0.051    0.000 {built-in method marshal.loads}
       34    0.041    0.001    0.041    0.001 {built-in method _imp.create_dynamic}
        1    0.035    0.035    0.036    0.036 /home/jk/Projekte/ocrd_all_2020/venv/lib/python3.8/site-packages/ocrd_browser/application.py:26(do_startup)
    20365    0.029    0.000    0.033    0.000 /home/jk/Projekte/ocrd_all_2020/venv/lib/python3.8/site-packages/pkg_resources/_vendor/pyparsing.py:363(__new__)
      455    0.024    0.000    0.024    0.000 {built-in method builtins.compile}
        1    0.024    0.024    0.052    0.052 /home/jk/Projekte/ocrd_all_2020/venv/lib/python3.8/site-packages/ocrd_browser/view/page.py:310(build)
1767/1717    0.022    0.000    0.105    0.000 {built-in method builtins.__build_class__}
     5075    0.021    0.000    0.048    0.000 /home/jk/Projekte/ocrd_all_2020/venv/lib/python3.8/site-packages/pkg_resources/_vendor/packaging/version.py:261(__init__)
20365/19896    0.020    0.000    0.030    0.000 /home/jk/Projekte/ocrd_all_2020/venv/lib/python3.8/site-packages/pkg_resources/_vendor/pyparsing.py:372(__init__)
        1    0.018    0.018    0.018    0.018 /home/jk/Projekte/ocrd_all_2020/venv/lib/python3.8/site-packages/ocrd_browser/view/base.py:141(__init__)
 1125/220    0.017    0.000    0.046    0.000 /usr/lib/python3.8/sre_parse.py:493(_parse)
     6433    0.017    0.000    0.017    0.000 {built-in method posix.stat}
 4796/652    0.016    0.000    0.211    0.000 /home/jk/Projekte/ocrd_all_2020/venv/lib/python3.8/site-packages/pkg_resources/_vendor/pyparsing.py:3547(parseImpl)
   156784    0.016    0.000    0.016    0.000 {built-in method builtins.isinstance}
       58    0.015    0.000    0.015    0.000 {method 'get_g_type' of 'gi.RegisteredTypeInfo' objects}
 4864/262    0.013    0.000    0.242    0.001 /home/jk/Projekte/ocrd_all_2020/venv/lib/python3.8/site-packages/pkg_resources/_vendor/pyparsing.py:3397(parseImpl)
        1    0.013    0.013    0.013    0.013 /home/jk/Projekte/ocrd_all_2020/venv/lib/python3.8/site-packages/ocrd_browser/util/gtk.py:65(WhenIdle)
     1320    0.011    0.000    0.043    0.000 <frozen importlib._bootstrap_external>:1498(find_spec)




$ STARTUP_PROFILE=1 browse-ocrd 
         791765 function calls (774883 primitive calls) in 0.864 seconds

   Ordered by: internal time
   List reduced from 4653 to 20 due to restriction <20>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      577    0.066    0.000    0.066    0.000 {built-in method marshal.loads}
        1    0.063    0.063    0.127    0.127 /home/jk/Projekte/ocrd_all_2020/venv/lib/python3.8/site-packages/ocrd_browser/application.py:53(do_activate)
       34    0.047    0.001    0.047    0.001 {built-in method _imp.create_dynamic}
        1    0.037    0.037    0.047    0.047 /home/jk/Projekte/ocrd_all_2020/venv/lib/python3.8/site-packages/ocrd_browser/application.py:26(do_startup)
      455    0.029    0.000    0.029    0.000 {built-in method builtins.compile}
1778/1727    0.024    0.000    0.095    0.000 {built-in method builtins.__build_class__}
        1    0.021    0.021    0.049    0.049 /home/jk/Projekte/ocrd_all_2020/venv/lib/python3.8/site-packages/ocrd_browser/view/page.py:310(build)
        1    0.019    0.019    0.019    0.019 /home/jk/Projekte/ocrd_all_2020/venv/lib/python3.8/site-packages/ocrd_browser/view/base.py:141(__init__)
 1127/219    0.017    0.000    0.046    0.000 /usr/lib/python3.8/sre_parse.py:493(_parse)
     6272    0.016    0.000    0.016    0.000 {built-in method posix.stat}
       57    0.015    0.000    0.015    0.000 {method 'get_g_type' of 'gi.RegisteredTypeInfo' objects}
      577    0.011    0.000    0.011    0.000 {built-in method io.open_code}
     1322    0.011    0.000    0.043    0.000 <frozen importlib._bootstrap_external>:1498(find_spec)
      916    0.010    0.000    0.013    0.000 /usr/lib/python3.8/sre_compile.py:276(_optimize_charset)
     2909    0.010    0.000    0.022    0.000 /home/jk/Projekte/ocrd_all_2020/venv/lib/python3.8/site-packages/pkg_resources/_vendor/packaging/version.py:261(__init__)
        1    0.009    0.009    0.184    0.184 /home/jk/Projekte/ocrd_all_2020/venv/lib/python3.8/site-packages/gi/overrides/Gio.py:39(run)
 1953/207    0.008    0.000    0.023    0.000 /usr/lib/python3.8/sre_compile.py:71(_compile)
    69525    0.007    0.000    0.008    0.000 {built-in method builtins.isinstance}
        2    0.007    0.003    0.007    0.003 /home/jk/Projekte/ocrd_all_2020/venv/lib/python3.8/site-packages/gi/_gtktemplate.py:175(init_template)
      457    0.006    0.000    0.006    0.000 {built-in method posix.listdir}
```