### PR TITLE
adapt to new import.metadata.entry_points API

### DIFF
--- a/ocrd_browser/application.py
+++ b/ocrd_browser/application.py
@@ -6,10 +6,7 @@ from ocrd_browser.util.gtk import ActionRegistry
 from ocrd_browser.ui import MainWindow, AboutDialog, OpenDialog
 from ocrd_browser.view import ViewRegistry
 
-try:
-    from importlib.metadata import entry_points
-except ModuleNotFoundError:
-    from importlib_metadata import entry_points  # type: ignore
+from importlib_metadata import entry_points  # type: ignore
 
 
 class OcrdBrowserApplication(Gtk.Application):
@@ -40,7 +37,7 @@ class OcrdBrowserApplication(Gtk.Application):
         self.set_accels_for_action('view.zoom_to::width', ['<Ctrl>numbersign'])
         self.set_accels_for_action('view.zoom_to::page', ['<Ctrl><Alt>numbersign'])
 
-        for entry_point in entry_points().get('ocrd_browser_ext', []):
+        for entry_point in entry_points(group='ocrd_browser_ext'):
             (entry_point.load())(self)
 
         self.load_css()

--- a/ocrd_browser/view/registry.py
+++ b/ocrd_browser/view/registry.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 from typing import Dict, Tuple, Optional, Type
 from .base import View
 
-try:
-    from importlib.metadata import entry_points
-except ModuleNotFoundError:
-    from importlib_metadata import entry_points  # type: ignore
+from importlib_metadata import entry_points  # type: ignore
 
 
 ViewInfo = Tuple[type, str, str]
@@ -18,7 +15,8 @@ class ViewRegistry:
     @classmethod
     def create_from_entry_points(cls) -> ViewRegistry:
         views = {}
-        for entry_point in entry_points().get('ocrd_browser_view', []):
+        # also loads view plugins, e.g. from browse-ocrd-physical-import
+        for entry_point in entry_points(group='ocrd_browser_view'):
             view_class = entry_point.load()
             assert issubclass(view_class, View)
             label = view_class.label if hasattr(view_class, 'label') else view_class.__name__

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ setuptools
 lxml
 Shapely
 Deprecated
-importlib_metadata;python_version<'3.8'
+importlib_metadata>=3.6
 importlib_resources;python_version<'3.8'


### PR DESCRIPTION
This fixes a regression which prevents running OCR-D Browser on Python < 3.10 and >= 3.8.

The reason is an ill-conceived [change in the importlib.metadata API](https://docs.python.org/3/library/importlib.metadata.html#entry-points): Starting with importlib_metadata>=5.0 (recently released), you can no longer directly use the old API, which directly accesses the dict from `entry_points()`. Alas, the new API is not available in native importlib.metadata for Python 3.8 and Python 3.9.

There is a [backport shim](https://pypi.org/project/backports.entry-points-selectable/) specifically for that problem, but I really resent that additional complication.

I therefore just switched to `importlib_metadata >= 3.6` and the new API throughout.