### PR TITLE
Dockerfile: use local pkg, not PyPI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,18 @@
 FROM python:3.7
 
-COPY Makefile /Makefile
+WORKDIR /
+COPY Makefile .
+COPY setup.cfg .
+COPY setup.py .
+COPY requirements.txt .
+COPY README.md .
+COPY ocrd_browser ocrd_browser
 RUN apt-get update \
     && apt-get install -y --no-install-recommends python3-dev make \
-    && make -f /Makefile deps-ubuntu \
-    && pip3 install -U setuptools --use-feature=2020-resolver \
-    && pip3 install browse-ocrd --use-feature=2020-resolver \
-    && rm /Makefile
+    && make deps-ubuntu \
+    && pip3 install -U setuptools pip \
+    && pip3 install -e / \
+    && rm Makefile
 
 MAINTAINER https://github.com/hnesk/browse-ocrd/issues
 
@@ -18,8 +24,7 @@ EXPOSE 8080
 
 VOLUME /data
 
-COPY init.sh /init.sh
-COPY serve.py /serve.py
+COPY init.sh .
+COPY serve.py .
 
-WORKDIR /
 CMD ["/init.sh", "/data"]


### PR DESCRIPTION
This fixes the current Docker build, which currently still runs into the problem fixed by https://github.com/hnesk/browse-ocrd/pull/53 – because the build used to install ocrd_browser via PyPI instead of the locally checked out sources, and there has not been a new PyPI release since 0.5.3. (So this affected both the Dockerhub images and the local build.)