### PR TITLE
Document.reorder: invalidate OcrdMets cache before save

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ codespell: deps-dev
 
 test: tests/assets deps-dev
 	$(PYTHON) -m xmlrunner discover -v -s tests --output-file $(CURDIR)/unittest.xml
+	OCRD_METS_CACHING=true $(PYTHON) -m xmlrunner discover -v -s tests --output-file $(CURDIR)/unittest.xml
 
 ci: flake8 mypy test codespell
 

--- a/ocrd_browser/model/document.py
+++ b/ocrd_browser/model/document.py
@@ -354,6 +354,7 @@ class Document:
             page_sequence.append(div)
 
         old_to_new = dict(zip(old_page_ids, self.page_ids))
+        self.workspace.mets.refresh_caches()
         self.save_mets()
         self._emit('document_changed', 'reordered', old_to_new)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ocrd
+ocrd >= 2.43.0
 Pillow
 numpy >= 1.20
 opencv-python-headless


### PR DESCRIPTION
As discussed in OCR-D/core#957, the `reorder` method of `Document` changes the XML structure without `OcrdMets` being aware of it. We introduced optional caching of METS data in [v2.42.0](https://github.com/OCR-D/core/releases/tag/v2.42.0) and when enabled this led to inconsistency because `OcrdMets.physical_pages` did not reflect the changes because caching hid them.

@mehmedGIT therefore [introduced](https://github.com/OCR-D/core/releases/tag/v2.43.0) a method `OcrdMets.refresh_caches` to refresh the cache from the XML.

This PR adds the refresh_caches call just before `self.save_mets()` which fixes the problem.

Also additonally run all tests with caching enabled to make sure we notice caching issues in the future.