### PR TITLE
RO: skip drawing arrow if start near end

### DIFF
--- a/ocrd_browser/model/page_xml_renderer.py
+++ b/ocrd_browser/model/page_xml_renderer.py
@@ -331,6 +331,9 @@ class ArrowOperation(Operation):
         angle = radians(180.0 - 30)  # 30 degrees
         c, s = cos(angle), sin(angle)
         d = self.p1[0] - self.p0[0], self.p1[1] - self.p0[1]
+        if np.isclose(d[0], 0) and np.isclose(d[1], 0):
+            # arrow start and end very close to each toerh
+            return
         left = d[0] * c - d[1] * s, d[0] * s + d[1] * c
         right = d[0] * c + d[1] * s, -d[0] * s + d[1] * c
         lf = self.size / (d[0] ** 2 + d[1] ** 2) ** 0.5

--- a/ocrd_browser/view/page.py
+++ b/ocrd_browser/view/page.py
@@ -519,6 +519,19 @@ class ViewPage(View):
             ]:
                 if hasattr(region.region, attribute) and getattr(region.region, attribute):
                     content += '\n<tt>@{}=</tt>{}'.format(attribute, getattr(region.region, attribute))
+            if hasattr(region.region, 'Roles') and getattr(region.region, 'Roles'):
+                roles = getattr(region.region, 'Roles')
+                if hasattr(roles, 'TableCellRole') and getattr(roles, 'TableCellRole'):
+                    cellrole = getattr(roles, 'TableCellRole')
+                    for attribute in [
+                            'rowIndex',
+                            'columnIndex',
+                            'rowSpan',
+                            'colSpan',
+                            'header',
+                    ]:
+                        if hasattr(cellrole, attribute):
+                            content += '\n<tt>@{}=</tt>{}'.format(attribute, getattr(cellrole, attribute))
             if hasattr(region.region, 'TextStyle') and getattr(region.region, 'TextStyle'):
                 style = getattr(region.region, 'TextStyle')
                 for attribute in [
@@ -543,7 +556,7 @@ class ViewPage(View):
                         'smallCaps',
                         'letterSpaced',
                 ]:
-                    if getattr(style, attribute):
+                    if hasattr(style, attribute):
                         content += '\n<tt>@{}=</tt>{}'.format(attribute, getattr(style, attribute))
             if region.warnings:
                 content += '\n\nWarnings:' + ('\n '.join(region.warnings))


### PR DESCRIPTION
fixes a rare bug where reading order display could crash:
```
Traceback (most recent call last):
  File "/data/ocr-d/ocrd_all/venv/lib/python3.7/site-packages/ocrd_browser/util/gtk.py", line 109, in _run
    callback()
  File "/data/ocr-d/ocrd_all/venv/lib/python3.7/site-packages/ocrd_browser/util/gtk.py", line 66, in __call__
    self.callback(*self.args, **self.kwargs)
  File "/data/ocr-d/ocrd_all/venv/lib/python3.7/site-packages/ocrd_browser/view/page.py", line 378, in redraw
    self.page_image, self.region_map = renderer.get_result()
  File "/data/ocr-d/ocrd_all/venv/lib/python3.7/site-packages/ocrd_browser/model/page_xml_renderer.py", line 548, in get_result
    canvas, regions = self.operations.paint(self.canvas.copy())
  File "/data/ocr-d/ocrd_all/venv/lib/python3.7/site-packages/ocrd_browser/model/page_xml_renderer.py", line 406, in paint
    operation.paint(draw, regions)
  File "/data/ocr-d/ocrd_all/venv/lib/python3.7/site-packages/ocrd_browser/model/page_xml_renderer.py", line 336, in paint
    lf = self.size / (d[0] ** 2 + d[1] ** 2) ** 0.5
ZeroDivisionError: float division by zero
```